### PR TITLE
Fix CI for semantic-release and separate grouped interventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           version: ">=0.4.25,<0.5"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --group dev
 
       - name: Python Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-        run: uv run semantic-release version
+        run: uv run semantic-release version --vcs-release
         # Crée le tag + GitHub Release + met à jour pyproject.toml + génère CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,5 @@ jobs:
       - name: Python Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-        run: uv run semantic-release version --no-vcs-release
-        # Crée le tag + met à jour pyproject.toml + génère CHANGELOG.md
-
-      - name: Publish GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-        run: uv run semantic-release publish
+        run: uv run semantic-release version
+        # Crée le tag + GitHub Release + met à jour pyproject.toml + génère CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ uv run pytest
 uv run uvicorn app.main:app --reload
 ```
 
-Le serveur démarre sur http://localhost:8000. Les données de `data/rfe.json` (47 interventions, 2 spécialités) sont chargées en mémoire au démarrage.
+Le serveur démarre sur http://localhost:8000. Les données de `data/rfe.json` (406 interventions, 21 spécialités) sont chargées en mémoire au démarrage.
 
 ### Endpoints disponibles
 
@@ -66,8 +66,8 @@ curl http://localhost:8000/api/v1/health
   "status": "ok",
   "version": "0.1.0",
   "data_version": "RFE SFAR 2024",
-  "specialites": 2,
-  "interventions": 47
+  "specialites": 21,
+  "interventions": 406
 }
 ```
 

--- a/data/rfe.json
+++ b/data/rfe.json
@@ -1036,8 +1036,8 @@
           "notes": null
         },
         {
-          "id": "neuro-derivation-externe",
-          "nom": "Dérivation ventriculaire externe (DVE) / Dérivation lombaire externe (DLE)",
+          "id": "neuro-derivation-externe-part1",
+          "nom": "Dérivation ventriculaire externe (DVE)",
           "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 38,
@@ -1047,8 +1047,34 @@
           "notes": null
         },
         {
-          "id": "neuro-derivation-interne",
-          "nom": "Dérivation ventriculo-péritonéale (DVP) / Dérivation ventriculo-atriale (DVA)",
+          "id": "neuro-derivation-externe-part2",
+          "nom": "Dérivation lombaire externe (DLE)",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 38,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Dérivation ventriculaire externe",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "neuro-derivation-interne-part1",
+          "nom": "Dérivation ventriculo-péritonéale (DVP)",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 38,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Dérivation ventriculaire interne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "neuro-derivation-interne-part2",
+          "nom": "Dérivation ventriculo-atriale (DVA)",
           "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 38,
@@ -1148,8 +1174,8 @@
           "notes": null
         },
         {
-          "id": "neuro-rachis-sans-materiel",
-          "nom": "Chirurgie du rachis sans mise en place de matériel (canal lombaire étroit, laminectomie, voie endoscopique, etc.) / Ablation de matériel du rachis",
+          "id": "neuro-rachis-sans-materiel-part1",
+          "nom": "Chirurgie du rachis sans mise en place de matériel (canal lombaire étroit, laminectomie, voie endoscopique, etc.)",
           "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 39,
@@ -1159,8 +1185,19 @@
           "notes": "En cas d'ablation de matériel d'ostéosynthèse ou de chirurgie sans pose de matériel exposant à une ouverture de la dure-mère, ou de geste prévu comme difficile/avec temps opératoire long, une antibioprophylaxie par céfazoline peut être discutée au cas par cas (Avis d'experts)."
         },
         {
-          "id": "neuro-stimulateur-electrode",
-          "nom": "Pose de pompe à destination médullaire / Pose d'électrode de stimulation cérébrale ou médullaire / Pose de stimulateur",
+          "id": "neuro-rachis-sans-materiel-part2",
+          "nom": "Ablation de matériel du rachis",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 39,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Chirurgie du rachis",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "En cas d'ablation de matériel d'ostéosynthèse ou de chirurgie sans pose de matériel exposant à une ouverture de la dure-mère, ou de geste prévu comme difficile/avec temps opératoire long, une antibioprophylaxie par céfazoline peut être discutée au cas par cas (Avis d'experts)."
+        },
+        {
+          "id": "neuro-stimulateur-electrode-part1",
+          "nom": "Pose de pompe à destination médullaire",
           "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 39,
@@ -1174,8 +1211,49 @@
           "notes": null
         },
         {
-          "id": "neuro-angiographie-embolisation",
-          "nom": "Angiographie, endoprothèse, stent, angioplastie des artères cervicales et cérébrales / Embolisation d'anévrysme ou de malformation artério-veineuse cérébrale et spinale",
+          "id": "neuro-stimulateur-electrode-part2",
+          "nom": "Pose d'électrode de stimulation cérébrale ou médullaire",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 39,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Électrode de stimulation cérébrale ou médullaire et pose de stimulateur",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "neuro-stimulateur-electrode-part3",
+          "nom": "Pose de stimulateur",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 39,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Électrode de stimulation cérébrale ou médullaire et pose de stimulateur",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "neuro-angiographie-embolisation-part1",
+          "nom": "Angiographie, endoprothèse, stent, angioplastie des artères cervicales et cérébrales",
+          "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 39,
+          "source_tableau": "Tableau Neurochirurgie et neuroradiologie interventionnelle — Neuroradiologie interventionnelle",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "neuro-angiographie-embolisation-part2",
+          "nom": "Embolisation d'anévrysme ou de malformation artério-veineuse cérébrale et spinale",
           "specialite": "Neurochirurgie et neuroradiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 39,
@@ -1202,8 +1280,8 @@
       "nom": "Chirurgie ORL",
       "interventions": [
         {
-          "id": "orl-sinusite-polypose",
-          "nom": "Chirurgie sinusienne de polypose ou sinusite chronique (méatotomie, éthmoidectomie, sphénoidectomie, polypectomie) / Chirurgie rhinologique sans mise en place de greffon",
+          "id": "orl-sinusite-polypose-part1",
+          "nom": "Chirurgie sinusienne de polypose ou sinusite chronique (méatotomie, éthmoidectomie, sphénoidectomie, polypectomie)",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "Avis d'experts",
           "source_page": 40,
@@ -1213,8 +1291,41 @@
           "notes": "Chirurgie sinusienne de polypose : Avis d'experts. Chirurgie rhinologique sans greffon : GRADE 2."
         },
         {
-          "id": "orl-rhinologique-avec-greffon",
-          "nom": "Chirurgie rhinologique avec mise en place d'un greffon ou reprise chirurgicale / Chirurgie sinusienne tumorale",
+          "id": "orl-sinusite-polypose-part2",
+          "nom": "Chirurgie rhinologique sans mise en place de greffon",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 40,
+          "source_tableau": "Tableau Chirurgie ORL — Chirurgie rhino-sinusienne",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Chirurgie sinusienne de polypose : Avis d'experts. Chirurgie rhinologique sans greffon : GRADE 2."
+        },
+        {
+          "id": "orl-rhinologique-avec-greffon-part1",
+          "nom": "Chirurgie rhinologique avec mise en place d'un greffon ou reprise chirurgicale",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "GRADE 2",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Chirurgie rhino-sinusienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Amoxicilline/Clavulanate 2g IVL (réinjection 1g si durée > 2h, puis toutes les 2h). Chirurgie sinusienne tumorale : Avis d'experts."
+        },
+        {
+          "id": "orl-rhinologique-avec-greffon-part2",
+          "nom": "Chirurgie sinusienne tumorale",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "GRADE 2",
           "source_page": 41,
@@ -1291,8 +1402,8 @@
           "notes": null
         },
         {
-          "id": "orl-amygdalectomie-adenoidectomie",
-          "nom": "Amygdalectomie / Adénoïdectomie",
+          "id": "orl-amygdalectomie-adenoidectomie-part1",
+          "nom": "Amygdalectomie",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "GRADE 1",
           "source_page": 41,
@@ -1302,8 +1413,63 @@
           "notes": null
         },
         {
-          "id": "orl-cervicotomie-pas-abp",
-          "nom": "Curage cervical / Thyroïdectomie totale / Thyroïdectomie partielle / Parathyroïdectomie / Trachéotomie percutanée",
+          "id": "orl-amygdalectomie-adenoidectomie-part2",
+          "nom": "Adénoïdectomie",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "GRADE 1",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Chirurgie amygdalienne et adénoïdectomie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-cervicotomie-pas-abp-part1",
+          "nom": "Curage cervical",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Cervicotomie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-cervicotomie-pas-abp-part2",
+          "nom": "Thyroïdectomie totale",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Cervicotomie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-cervicotomie-pas-abp-part3",
+          "nom": "Thyroïdectomie partielle",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Cervicotomie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-cervicotomie-pas-abp-part4",
+          "nom": "Parathyroïdectomie",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 41,
+          "source_tableau": "Tableau Chirurgie ORL — Cervicotomie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-cervicotomie-pas-abp-part5",
+          "nom": "Trachéotomie percutanée",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "Avis d'experts",
           "source_page": 41,
@@ -1374,8 +1540,8 @@
           "notes": null
         },
         {
-          "id": "orl-laryngoscopie-suspension",
-          "nom": "Laryngoscopie en suspension diagnostique sans ou avec biopsies / Laryngoscopie en suspension avec geste thérapeutique (laser, cordectomie, etc.)",
+          "id": "orl-laryngoscopie-suspension-part1",
+          "nom": "Laryngoscopie en suspension diagnostique sans ou avec biopsies",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "Avis d'experts",
           "source_page": 42,
@@ -1385,8 +1551,41 @@
           "notes": null
         },
         {
-          "id": "orl-tympan-ossiculaire-cholesteatome",
-          "nom": "Chirurgie des tympans (tympanoplastie, myringoplastie, tympanotomie exploratrice, perforation tympanique) / Chirurgie de la chaîne ossiculaire, stapédectomie, ossiculoplastie, otospongiose / Chirurgie de cholestéatome (non infecté)",
+          "id": "orl-laryngoscopie-suspension-part2",
+          "nom": "Laryngoscopie en suspension avec geste thérapeutique (laser, cordectomie, etc.)",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 42,
+          "source_tableau": "Tableau Chirurgie ORL — Laryngoscopie en suspension",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-tympan-ossiculaire-cholesteatome-part1",
+          "nom": "Chirurgie des tympans (tympanoplastie, myringoplastie, tympanotomie exploratrice, perforation tympanique)",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "GRADE 2",
+          "source_page": 42,
+          "source_tableau": "Tableau Chirurgie ORL — Chirurgie otologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-tympan-ossiculaire-cholesteatome-part2",
+          "nom": "Chirurgie de la chaîne ossiculaire, stapédectomie, ossiculoplastie, otospongiose",
+          "specialite": "Chirurgie ORL",
+          "force_recommandation": "GRADE 2",
+          "source_page": 42,
+          "source_tableau": "Tableau Chirurgie ORL — Chirurgie otologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "orl-tympan-ossiculaire-cholesteatome-part3",
+          "nom": "Chirurgie de cholestéatome (non infecté)",
           "specialite": "Chirurgie ORL",
           "force_recommandation": "GRADE 2",
           "source_page": 42,
@@ -1485,8 +1684,41 @@
           "notes": null
         },
         {
-          "id": "stomato-pas-abp-dentaire",
-          "nom": "Autres extractions dentaires (dents sur arcade, etc.) / Pose de matériel d'ancrage orthodontique / Chirurgie apicale / Chirurgie alvéolaire (greffe osseuse d'apposition, régénération osseuse alvéolaire, ostéoplastie segmentaire, sinus lift, etc.)",
+          "id": "stomato-pas-abp-dentaire-part1",
+          "nom": "Autres extractions dentaires (dents sur arcade, etc.)",
+          "specialite": "Chirurgie stomatologique et maxillo-faciale",
+          "force_recommandation": "GRADE 1",
+          "source_page": 44,
+          "source_tableau": "Tableau Chirurgie stomatologique et maxillo-faciale — Chirurgie alvéolo-dentaire",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Autres extractions : GRADE 1. Matériel orthodontique, chirurgie apicale, alvéolaire : Avis d'experts."
+        },
+        {
+          "id": "stomato-pas-abp-dentaire-part2",
+          "nom": "Pose de matériel d'ancrage orthodontique",
+          "specialite": "Chirurgie stomatologique et maxillo-faciale",
+          "force_recommandation": "GRADE 1",
+          "source_page": 44,
+          "source_tableau": "Tableau Chirurgie stomatologique et maxillo-faciale — Chirurgie alvéolo-dentaire",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Autres extractions : GRADE 1. Matériel orthodontique, chirurgie apicale, alvéolaire : Avis d'experts."
+        },
+        {
+          "id": "stomato-pas-abp-dentaire-part3",
+          "nom": "Chirurgie apicale",
+          "specialite": "Chirurgie stomatologique et maxillo-faciale",
+          "force_recommandation": "GRADE 1",
+          "source_page": 44,
+          "source_tableau": "Tableau Chirurgie stomatologique et maxillo-faciale — Chirurgie alvéolo-dentaire",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Autres extractions : GRADE 1. Matériel orthodontique, chirurgie apicale, alvéolaire : Avis d'experts."
+        },
+        {
+          "id": "stomato-pas-abp-dentaire-part4",
+          "nom": "Chirurgie alvéolaire (greffe osseuse d'apposition, régénération osseuse alvéolaire, ostéoplastie segmentaire, sinus lift, etc.)",
           "specialite": "Chirurgie stomatologique et maxillo-faciale",
           "force_recommandation": "GRADE 1",
           "source_page": 44,
@@ -1624,8 +1856,8 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h + 0,75g lors du priming si CEC)."
         },
         {
-          "id": "cardio-drainage-pericardique",
-          "nom": "Drainage péricardique par thoracotomie ou sternotomie / Fenêtre pleuropéricardique ou péritonéopéricardique / Hémostase postopératoire de chirurgie cardiaque par sternotomie ou thoracotomie",
+          "id": "cardio-drainage-pericardique-part1",
+          "nom": "Drainage péricardique par thoracotomie ou sternotomie",
           "specialite": "Chirurgie cardiaque",
           "force_recommandation": "Avis d'experts",
           "source_page": 47,
@@ -1652,8 +1884,64 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "cardio-transplantation-sans-assistance",
-          "nom": "Transplantation cardiaque chez un patient arrivant de son domicile, sans assistance mécanique de longue durée / Assistance circulatoire gauche (LVAD) ou cœur artificiel, sans contexte de réanimation préopératoire",
+          "id": "cardio-drainage-pericardique-part2",
+          "nom": "Fenêtre pleuropéricardique ou péritonéopéricardique",
+          "specialite": "Chirurgie cardiaque",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 47,
+          "source_tableau": "Tableau Chirurgie cardiaque — Chirurgie cardiaque",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "cardio-drainage-pericardique-part3",
+          "nom": "Hémostase postopératoire de chirurgie cardiaque par sternotomie ou thoracotomie",
+          "specialite": "Chirurgie cardiaque",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 47,
+          "source_tableau": "Tableau Chirurgie cardiaque — Chirurgie cardiaque",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "cardio-transplantation-sans-assistance-part1",
+          "nom": "Transplantation cardiaque chez un patient arrivant de son domicile, sans assistance mécanique de longue durée",
           "specialite": "Chirurgie cardiaque",
           "force_recommandation": "Avis d'experts",
           "source_page": 47,
@@ -1680,8 +1968,47 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "cardio-transplantation-avec-assistance",
-          "nom": "Transplantation cardiaque chez un patient porteur d'une assistance mécanique de longue durée (cœur artificiel ou LVAD), ou de courte durée (ECMO), sans ou avec antécédent d'infection / Assistance circulatoire gauche (LVAD) ou cœur artificiel avec contexte de réanimation préopératoire",
+          "id": "cardio-transplantation-sans-assistance-part2",
+          "nom": "Assistance circulatoire gauche (LVAD) ou cœur artificiel, sans contexte de réanimation préopératoire",
+          "specialite": "Chirurgie cardiaque",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 47,
+          "source_tableau": "Tableau Chirurgie cardiaque — Transplantation cardiaque et assistance circulatoire de longue durée",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "cardio-transplantation-avec-assistance-part1",
+          "nom": "Transplantation cardiaque chez un patient porteur d'une assistance mécanique de longue durée (cœur artificiel ou LVAD), ou de courte durée (ECMO), sans ou avec antécédent d'infection",
+          "specialite": "Chirurgie cardiaque",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 47,
+          "source_tableau": "Tableau Chirurgie cardiaque — Transplantation cardiaque et assistance circulatoire de longue durée",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Modalités de l'antibioprophylaxie (molécule(s) et durée) à discuter individuellement après avis infectiologique spécialisé, tenant compte des antécédents infectieux et de la colonisation à SARM ou E-BLSE."
+        },
+        {
+          "id": "cardio-transplantation-avec-assistance-part2",
+          "nom": "Assistance circulatoire gauche (LVAD) ou cœur artificiel avec contexte de réanimation préopératoire",
           "specialite": "Chirurgie cardiaque",
           "force_recommandation": "Avis d'experts",
           "source_page": 47,
@@ -1736,8 +2063,92 @@
       "nom": "Cardiologie structurelle",
       "interventions": [
         {
-          "id": "struct-tavi-fermeture-mitraclip",
-          "nom": "Bioprothèse de la valve aortique par voie artérielle transcutanée (TAVI) ou autre bioprothèse valvulaire par voie transcutanée / Fermeture d'auricule par voie percutanée avec implantation de matériel / Rétrécissement de l'orifice atrioventriculaire gauche (MitraClip) / Fermeture de communication interatriale ou de foramen ovale perméable",
+          "id": "struct-tavi-fermeture-mitraclip-part1",
+          "nom": "Bioprothèse de la valve aortique par voie artérielle transcutanée (TAVI) ou autre bioprothèse valvulaire par voie transcutanée",
+          "specialite": "Cardiologie structurelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 48,
+          "source_tableau": "Tableau Cardiologie structurelle — Cardiologie structurelle",
+          "protocole": {
+            "molecule": "Amoxicilline/Clavulanate",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfazoline 2g IVL (réinjection 1g si durée > 4h, puis toutes les 4h) + Amoxicilline 2g IVL (réinjection 1g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "struct-tavi-fermeture-mitraclip-part2",
+          "nom": "Fermeture d'auricule par voie percutanée avec implantation de matériel",
+          "specialite": "Cardiologie structurelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 48,
+          "source_tableau": "Tableau Cardiologie structurelle — Cardiologie structurelle",
+          "protocole": {
+            "molecule": "Amoxicilline/Clavulanate",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfazoline 2g IVL (réinjection 1g si durée > 4h, puis toutes les 4h) + Amoxicilline 2g IVL (réinjection 1g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "struct-tavi-fermeture-mitraclip-part3",
+          "nom": "Rétrécissement de l'orifice atrioventriculaire gauche (MitraClip)",
+          "specialite": "Cardiologie structurelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 48,
+          "source_tableau": "Tableau Cardiologie structurelle — Cardiologie structurelle",
+          "protocole": {
+            "molecule": "Amoxicilline/Clavulanate",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfazoline 2g IVL (réinjection 1g si durée > 4h, puis toutes les 4h) + Amoxicilline 2g IVL (réinjection 1g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "struct-tavi-fermeture-mitraclip-part4",
+          "nom": "Fermeture de communication interatriale ou de foramen ovale perméable",
           "specialite": "Cardiologie structurelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 48,
@@ -1770,8 +2181,8 @@
       "nom": "Rythmologie interventionnelle",
       "interventions": [
         {
-          "id": "rythmo-implantation-prothese",
-          "nom": "Implantation, explantation ou changement de stimulateur ou défibrillateur / Implantation, explantation ou changement de sonde de stimulation ou de défibrillation",
+          "id": "rythmo-implantation-prothese-part1",
+          "nom": "Implantation, explantation ou changement de stimulateur ou défibrillateur",
           "specialite": "Rythmologie interventionnelle",
           "force_recommandation": "GRADE 1",
           "source_page": 49,
@@ -1798,8 +2209,47 @@
           "notes": null
         },
         {
-          "id": "rythmo-exploration-ablation",
-          "nom": "Exploration électrophysiologique endocavitaire atriale et/ou ventriculaire / Ablation de trouble du rythme cardiaque par cathéter (radiofréquence, cryothérapie, etc.) dans les cavités cardiaques droites ou gauches",
+          "id": "rythmo-implantation-prothese-part2",
+          "nom": "Implantation, explantation ou changement de sonde de stimulation ou de défibrillation",
+          "specialite": "Rythmologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 49,
+          "source_tableau": "Tableau Rythmologie interventionnelle — Implantation ou changement de prothèse rythmique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "rythmo-exploration-ablation-part1",
+          "nom": "Exploration électrophysiologique endocavitaire atriale et/ou ventriculaire",
+          "specialite": "Rythmologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 49,
+          "source_tableau": "Tableau Rythmologie interventionnelle — Explorations endocavitaires et ablations",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Si procédure chez un patient avec prothèse intracardiaque (rythmique ou non) déjà implantée : Céfazoline 2g IVL (Avis d'experts)."
+        },
+        {
+          "id": "rythmo-exploration-ablation-part2",
+          "nom": "Ablation de trouble du rythme cardiaque par cathéter (radiofréquence, cryothérapie, etc.) dans les cavités cardiaques droites ou gauches",
           "specialite": "Rythmologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 49,
@@ -1815,8 +2265,36 @@
       "nom": "Chirurgie vasculaire",
       "interventions": [
         {
-          "id": "vascu-arterielle-avec-materiel",
-          "nom": "Chirurgie artérielle périphérique ou chirurgie aortique, avec ou sans mise en place de matériel / Chirurgie carotidienne avec mise en place de matériel",
+          "id": "vascu-arterielle-avec-materiel-part1",
+          "nom": "Chirurgie artérielle périphérique ou chirurgie aortique, avec ou sans mise en place de matériel",
+          "specialite": "Chirurgie vasculaire",
+          "force_recommandation": "GRADE 1",
+          "source_page": 50,
+          "source_tableau": "Tableau Chirurgie vasculaire — Chirurgie artérielle ouverte",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Artérielle périphérique/aortique : GRADE 1. Carotidienne avec matériel : GRADE 2. Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "vascu-arterielle-avec-materiel-part2",
+          "nom": "Chirurgie carotidienne avec mise en place de matériel",
           "specialite": "Chirurgie vasculaire",
           "force_recommandation": "GRADE 1",
           "source_page": 50,
@@ -1960,8 +2438,36 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "vascu-interventionnelle-stent-couvert",
-          "nom": "Stent couvert ou endoprothèse / Stent nu ou absence de mise en place de matériel chez un patient avec facteurs de risque",
+          "id": "vascu-interventionnelle-stent-couvert-part1",
+          "nom": "Stent couvert ou endoprothèse",
+          "specialite": "Chirurgie vasculaire",
+          "force_recommandation": "GRADE 2",
+          "source_page": 51,
+          "source_tableau": "Tableau Chirurgie vasculaire — Procédure interventionnelle vasculaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "vascu-interventionnelle-stent-couvert-part2",
+          "nom": "Stent nu ou absence de mise en place de matériel chez un patient avec facteurs de risque",
           "specialite": "Chirurgie vasculaire",
           "force_recommandation": "GRADE 2",
           "source_page": 51,
@@ -2027,8 +2533,8 @@
       "nom": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
       "interventions": [
         {
-          "id": "thorax-exerese-pulmonaire",
-          "nom": "Pneumonectomies ou lobectomies pulmonaires / Pleuro-pneumonectomies / Exérèses partielles non anatomiques simples ou multiples du poumon, par thoracotomie / Segmentectomie pulmonaire, par thoracotomie / Réduction uni- ou bilatérale de volume pulmonaire / Résection de bulle d'emphysème pulmonaire / Exérèse de kyste hydatique du poumon, par thoracotomie",
+          "id": "thorax-exerese-pulmonaire-part1",
+          "nom": "Pneumonectomies ou lobectomies pulmonaires",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "GRADE 1",
           "source_page": 53,
@@ -2049,8 +2555,140 @@
           "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
         },
         {
-          "id": "thorax-mediastin-plevre-paroi",
-          "nom": "Chirurgie du médiastin / Chirurgie du pneumothorax / Chirurgie de la plèvre (patient non infecté) / Chirurgie de paroi thoracique (avec ou sans pose de matériel)",
+          "id": "thorax-exerese-pulmonaire-part2",
+          "nom": "Pleuro-pneumonectomies",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-exerese-pulmonaire-part3",
+          "nom": "Exérèses partielles non anatomiques simples ou multiples du poumon, par thoracotomie",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-exerese-pulmonaire-part4",
+          "nom": "Segmentectomie pulmonaire, par thoracotomie",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-exerese-pulmonaire-part5",
+          "nom": "Réduction uni- ou bilatérale de volume pulmonaire",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-exerese-pulmonaire-part6",
+          "nom": "Résection de bulle d'emphysème pulmonaire",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-exerese-pulmonaire-part7",
+          "nom": "Exérèse de kyste hydatique du poumon, par thoracotomie",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "GRADE 1",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie d'exérèse pulmonaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Au choix : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfazoline 2g IVL ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). Pour la prévention des pneumonies post-opératoires chez les patients atteints de BPCO et/ou dans les centres à incidence élevée : privilégier Amoxicilline/Clavulanate (GRADE 2), durée jusqu'à 48h postopératoires max (Avis d'experts)."
+        },
+        {
+          "id": "thorax-mediastin-plevre-paroi-part1",
+          "nom": "Chirurgie du médiastin",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 53,
@@ -2071,8 +2709,74 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie)."
         },
         {
-          "id": "thorax-mediastinoscopie-thoracoscopie",
-          "nom": "Médiastinoscopie avec ou sans biopsie / Thoracoscopie/pleuroscopie avec ou sans biopsie, avec ou sans abrasion ou talcage / Drainage thoracique tunellisé ou non",
+          "id": "thorax-mediastin-plevre-paroi-part2",
+          "nom": "Chirurgie du pneumothorax",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgies médiastinales, pleurales, pariétales",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie)."
+        },
+        {
+          "id": "thorax-mediastin-plevre-paroi-part3",
+          "nom": "Chirurgie de la plèvre (patient non infecté)",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgies médiastinales, pleurales, pariétales",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie)."
+        },
+        {
+          "id": "thorax-mediastin-plevre-paroi-part4",
+          "nom": "Chirurgie de paroi thoracique (avec ou sans pose de matériel)",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 53,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgies médiastinales, pleurales, pariétales",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie)."
+        },
+        {
+          "id": "thorax-mediastinoscopie-thoracoscopie-part1",
+          "nom": "Médiastinoscopie avec ou sans biopsie",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 54,
@@ -2082,8 +2786,162 @@
           "notes": null
         },
         {
-          "id": "thorax-voies-aeriennes-sous-glottiques",
-          "nom": "Trachéotomie chirurgicale / Suture ou résection-anastomose de bronche / Plastie ou fermeture d'orifice de trachéostomie ou de trachéotomie / Tuteur trachéal / Fermeture de plaie ou fistule bronchique / Plastie et remplacement de trachée / Résection-anastomose trachéale",
+          "id": "thorax-mediastinoscopie-thoracoscopie-part2",
+          "nom": "Thoracoscopie/pleuroscopie avec ou sans biopsie, avec ou sans abrasion ou talcage",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgies médiastinales, pleurales, pariétales",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-mediastinoscopie-thoracoscopie-part3",
+          "nom": "Drainage thoracique tunellisé ou non",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgies médiastinales, pleurales, pariétales",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part1",
+          "nom": "Trachéotomie chirurgicale",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part2",
+          "nom": "Suture ou résection-anastomose de bronche",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part3",
+          "nom": "Plastie ou fermeture d'orifice de trachéostomie ou de trachéotomie",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part4",
+          "nom": "Tuteur trachéal",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part5",
+          "nom": "Fermeture de plaie ou fistule bronchique",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part6",
+          "nom": "Plastie et remplacement de trachée",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie des voies aériennes sous-glottiques",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternatives pharmacologiques : Amoxicilline/Clavulanate 2g IVL (1g si durée > 2h, puis toutes les 2h) ou Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "thorax-voies-aeriennes-sous-glottiques-part7",
+          "nom": "Résection-anastomose trachéale",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 54,
@@ -2115,8 +2973,8 @@
           "notes": null
         },
         {
-          "id": "thorax-oesophagectomie",
-          "nom": "Œsophagectomie / Excision de tumeur de l'œsophage / Traitement d'un diverticule de l'œsophage",
+          "id": "thorax-oesophagectomie-part1",
+          "nom": "Œsophagectomie",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 54,
@@ -2143,8 +3001,64 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). En cas d'allergie vraie aux bêtalactamines : vancomycine 20 mg/kg IVL ou teicoplanine 12 mg/kg IVL."
         },
         {
-          "id": "thorax-radio-interventionnelle-broncho-pulm",
-          "nom": "Destruction de tumeurs bronchopulmonaires par radiofréquence / Ponctions, cytoponctions ou biopsies pulmonaires par voie transcutanée / Évacuation ou drainages de collections broncho-pulmonaires / Injection d'agent pharmacologique intrapulmonaire",
+          "id": "thorax-oesophagectomie-part2",
+          "nom": "Excision de tumeur de l'œsophage",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie œsophagienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). En cas d'allergie vraie aux bêtalactamines : vancomycine 20 mg/kg IVL ou teicoplanine 12 mg/kg IVL."
+        },
+        {
+          "id": "thorax-oesophagectomie-part3",
+          "nom": "Traitement d'un diverticule de l'œsophage",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 54,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Chirurgie œsophagienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). En cas d'allergie vraie aux bêtalactamines : vancomycine 20 mg/kg IVL ou teicoplanine 12 mg/kg IVL."
+        },
+        {
+          "id": "thorax-radio-interventionnelle-broncho-pulm-part1",
+          "nom": "Destruction de tumeurs bronchopulmonaires par radiofréquence",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 55,
@@ -2154,8 +3068,63 @@
           "notes": null
         },
         {
-          "id": "thorax-fibroscopie-bronchique",
-          "nom": "Fibroscopie bronchique simple ou avec lavage broncho-alvéolaire / Fibroscopie + biopsies / Écho-endoscopie bronchique avec ponction trans-bronchique (EBUS)",
+          "id": "thorax-radio-interventionnelle-broncho-pulm-part2",
+          "nom": "Ponctions, cytoponctions ou biopsies pulmonaires par voie transcutanée",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Radiologie interventionnelle des voies respiratoires",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-radio-interventionnelle-broncho-pulm-part3",
+          "nom": "Évacuation ou drainages de collections broncho-pulmonaires",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Radiologie interventionnelle des voies respiratoires",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-radio-interventionnelle-broncho-pulm-part4",
+          "nom": "Injection d'agent pharmacologique intrapulmonaire",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Radiologie interventionnelle des voies respiratoires",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-fibroscopie-bronchique-part1",
+          "nom": "Fibroscopie bronchique simple ou avec lavage broncho-alvéolaire",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Fibroscopie ou écho-endoscopie diagnostique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-fibroscopie-bronchique-part2",
+          "nom": "Fibroscopie + biopsies",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Fibroscopie ou écho-endoscopie diagnostique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-fibroscopie-bronchique-part3",
+          "nom": "Écho-endoscopie bronchique avec ponction trans-bronchique (EBUS)",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 55,
@@ -2187,8 +3156,41 @@
           "notes": null
         },
         {
-          "id": "thorax-prothese-tracheo-bronchique",
-          "nom": "Prothèse trachéo-bronchique / Bronchoscopie rigide, désobstruction / Destruction de lésion par laser, cryothérapie / Dilatation ou résection de sténose",
+          "id": "thorax-prothese-tracheo-bronchique-part1",
+          "nom": "Prothèse trachéo-bronchique",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Pose de prothèse endo-bronchique ou valves",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-prothese-tracheo-bronchique-part2",
+          "nom": "Bronchoscopie rigide, désobstruction",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Pose de prothèse endo-bronchique ou valves",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-prothese-tracheo-bronchique-part3",
+          "nom": "Destruction de lésion par laser, cryothérapie",
+          "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 55,
+          "source_tableau": "Tableau Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle — Pose de prothèse endo-bronchique ou valves",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "thorax-prothese-tracheo-bronchique-part4",
+          "nom": "Dilatation ou résection de sténose",
           "specialite": "Chirurgie thoracique, endoscopie thoracique et radiologie interventionnelle",
           "force_recommandation": "Avis d'experts",
           "source_page": 55,
@@ -2294,8 +3296,8 @@
           "notes": "Pas d'indication à prolonger l'antibioprophylaxie au-delà de la fin de chirurgie (GRADE 2)."
         },
         {
-          "id": "plast-mamm-reduction-mastopexie-tumorectomie",
-          "nom": "Chirurgie de réduction mammaire / Exérèse de gynécomastie / Mastopexie pour ptose simple / Tumorectomie mammaire sans curage / Tumorectomie mammaire avec ganglion sentinelle / Gonflage d'expandeur",
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part1",
+          "nom": "Chirurgie de réduction mammaire",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "Avis d'experts",
           "source_page": 57,
@@ -2305,8 +3307,97 @@
           "notes": null
         },
         {
-          "id": "plast-mamm-tumorectomie-curage-mastectomie",
-          "nom": "Tumorectomie mammaire avec curage / Mastectomie sans ou avec curage : sans reconstruction ou avec reconstruction immédiate (prothèse d'expansion, lambeau) ou reconstruction différée",
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part2",
+          "nom": "Exérèse de gynécomastie",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part3",
+          "nom": "Mastopexie pour ptose simple",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part4",
+          "nom": "Tumorectomie mammaire sans curage",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part5",
+          "nom": "Tumorectomie mammaire avec ganglion sentinelle",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-mamm-reduction-mastopexie-tumorectomie-part6",
+          "nom": "Gonflage d'expandeur",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-mamm-tumorectomie-curage-mastectomie-part1",
+          "nom": "Tumorectomie mammaire avec curage",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 57,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie mammaire plastique ou carcinologique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 3,
+              "reinjection": null
+            }
+          ],
+          "notes": "Tumorectomie avec curage et mastectomie sans reconstruction : GRADE 2. Mastectomie avec reconstruction : Avis d'experts. Pas d'indication à prolonger l'antibioprophylaxie au-delà de la fin de chirurgie (GRADE 2)."
+        },
+        {
+          "id": "plast-mamm-tumorectomie-curage-mastectomie-part2",
+          "nom": "Mastectomie sans ou avec curage : sans reconstruction ou avec reconstruction immédiate (prothèse d'expansion, lambeau) ou reconstruction différée",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "GRADE 2",
           "source_page": 57,
@@ -2474,8 +3565,19 @@
           "notes": null
         },
         {
-          "id": "plast-tete-otoplastie-blepharoplastie",
-          "nom": "Otoplastie / Blépharoplastie",
+          "id": "plast-tete-otoplastie-blepharoplastie-part1",
+          "nom": "Otoplastie",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 58,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie de la tête et du cou",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "plast-tete-otoplastie-blepharoplastie-part2",
+          "nom": "Blépharoplastie",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "Avis d'experts",
           "source_page": 58,
@@ -2496,8 +3598,42 @@
           "notes": null
         },
         {
-          "id": "plast-tete-lifting-long-osseux",
-          "nom": "Lifting cervico-facial ou mask-lift de durée > 2h / Avec greffon ou remodelage osseux",
+          "id": "plast-tete-lifting-long-osseux-part1",
+          "nom": "Lifting cervico-facial ou mask-lift de durée > 2h",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 58,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie de la tête et du cou",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 3,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "plast-tete-lifting-long-osseux-part2",
+          "nom": "Avec greffon ou remodelage osseux",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "Avis d'experts",
           "source_page": 58,
@@ -2541,8 +3677,42 @@
           "notes": null
         },
         {
-          "id": "plast-tete-rhinoplastie-avec-greffe",
-          "nom": "Septo-rhinoplastie avec greffe de cartilage / Implants ou appositions modelantes à la face (malaire)",
+          "id": "plast-tete-rhinoplastie-avec-greffe-part1",
+          "nom": "Septo-rhinoplastie avec greffe de cartilage",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 58,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie de la tête et du cou",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 3,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "plast-tete-rhinoplastie-avec-greffe-part2",
+          "nom": "Implants ou appositions modelantes à la face (malaire)",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "GRADE 2",
           "source_page": 58,
@@ -2776,8 +3946,52 @@
           "notes": null
         },
         {
-          "id": "plast-gen-greffes-cutanees",
-          "nom": "Greffes cutanées (hors brûlure) / Plastie(s) cutanée(s) / Tumorectomie cutanée / Chirurgie de ganglion sentinelle / Curage ganglionnaire axillaire ou inguinal seul",
+          "id": "plast-gen-greffes-cutanees-part1",
+          "nom": "Greffes cutanées (hors brûlure)",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 59,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie générale et carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Greffes cutanées, plastie(s) cutanée(s) : GRADE 2. Tumorectomie cutanée, ganglion sentinelle, curage : Avis d'experts."
+        },
+        {
+          "id": "plast-gen-greffes-cutanees-part2",
+          "nom": "Plastie(s) cutanée(s)",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 59,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie générale et carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Greffes cutanées, plastie(s) cutanée(s) : GRADE 2. Tumorectomie cutanée, ganglion sentinelle, curage : Avis d'experts."
+        },
+        {
+          "id": "plast-gen-greffes-cutanees-part3",
+          "nom": "Tumorectomie cutanée",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 59,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie générale et carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Greffes cutanées, plastie(s) cutanée(s) : GRADE 2. Tumorectomie cutanée, ganglion sentinelle, curage : Avis d'experts."
+        },
+        {
+          "id": "plast-gen-greffes-cutanees-part4",
+          "nom": "Chirurgie de ganglion sentinelle",
+          "specialite": "Chirurgie plastique et reconstructrice",
+          "force_recommandation": "GRADE 2",
+          "source_page": 59,
+          "source_tableau": "Tableau Chirurgie plastique et reconstructrice — Chirurgie générale et carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Greffes cutanées, plastie(s) cutanée(s) : GRADE 2. Tumorectomie cutanée, ganglion sentinelle, curage : Avis d'experts."
+        },
+        {
+          "id": "plast-gen-greffes-cutanees-part5",
+          "nom": "Curage ganglionnaire axillaire ou inguinal seul",
           "specialite": "Chirurgie plastique et reconstructrice",
           "force_recommandation": "GRADE 2",
           "source_page": 59,
@@ -2906,8 +4120,8 @@
       "nom": "Chirurgie d'affirmation de genre",
       "interventions": [
         {
-          "id": "genre-protheses-peniennes-testiculaires",
-          "nom": "Pose de prothèse testiculaire / Pose de prothèse pénienne / Armature d'un néo-pénis / Pose de prothèses gonflables (hydrauliques) avec composants extra-caverneux / Pose de prothèses semi-rigide",
+          "id": "genre-protheses-peniennes-testiculaires-part1",
+          "nom": "Pose de prothèse testiculaire",
           "specialite": "Chirurgie d'affirmation de genre",
           "force_recommandation": "Avis d'experts",
           "source_page": 60,
@@ -2934,8 +4148,164 @@
           "notes": null
         },
         {
-          "id": "genre-vaginoplastie",
-          "nom": "Urétroplastie, vaginoplastie et vestibuloplastie avec enfouissement ou réduction du clitoris pour féminisation / Création d'un néo-vagin et d'une néo-vulve +/- greffe de peau / Plastie des organes génitaux externes pour transsexualisme masculin",
+          "id": "genre-protheses-peniennes-testiculaires-part2",
+          "nom": "Pose de prothèse pénienne",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Prothèses pénienne et testiculaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "genre-protheses-peniennes-testiculaires-part3",
+          "nom": "Armature d'un néo-pénis",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Prothèses pénienne et testiculaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "genre-protheses-peniennes-testiculaires-part4",
+          "nom": "Pose de prothèses gonflables (hydrauliques) avec composants extra-caverneux",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Prothèses pénienne et testiculaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "genre-protheses-peniennes-testiculaires-part5",
+          "nom": "Pose de prothèses semi-rigide",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Prothèses pénienne et testiculaire",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "genre-vaginoplastie-part1",
+          "nom": "Urétroplastie, vaginoplastie et vestibuloplastie avec enfouissement ou réduction du clitoris pour féminisation",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Vaginoplastie",
+          "protocole": {
+            "molecule": "Amoxicilline/Clavulanate",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "En cas de création de néo-vagin, poursuite de l'Amoxicilline/Clavulanate 1g/6h (si allergie : Métronidazole 500mg/8h) jusqu'à ablation du conformateur vaginal (Avis d'experts)."
+        },
+        {
+          "id": "genre-vaginoplastie-part2",
+          "nom": "Création d'un néo-vagin et d'une néo-vulve +/- greffe de peau",
+          "specialite": "Chirurgie d'affirmation de genre",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 60,
+          "source_tableau": "Tableau Chirurgie d'affirmation de genre — Vaginoplastie",
+          "protocole": {
+            "molecule": "Amoxicilline/Clavulanate",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "En cas de création de néo-vagin, poursuite de l'Amoxicilline/Clavulanate 1g/6h (si allergie : Métronidazole 500mg/8h) jusqu'à ablation du conformateur vaginal (Avis d'experts)."
+        },
+        {
+          "id": "genre-vaginoplastie-part3",
+          "nom": "Plastie des organes génitaux externes pour transsexualisme masculin",
           "specialite": "Chirurgie d'affirmation de genre",
           "force_recommandation": "Avis d'experts",
           "source_page": 60,
@@ -3062,8 +4432,19 @@
           "notes": null
         },
         {
-          "id": "brule-incision-decharge",
-          "nom": "Incision de décharge : escarrotomie / Aponévrotomie (en l'absence de fracture ouverte associée)",
+          "id": "brule-incision-decharge-part1",
+          "nom": "Incision de décharge : escarrotomie",
+          "specialite": "Chirurgie du patient brûlé",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 63,
+          "source_tableau": "Tableau Chirurgie du patient brûlé",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "brule-incision-decharge-part2",
+          "nom": "Aponévrotomie (en l'absence de fracture ouverte associée)",
           "specialite": "Chirurgie du patient brûlé",
           "force_recommandation": "Avis d'experts",
           "source_page": 63,
@@ -3163,8 +4544,30 @@
           "notes": "Considérer une antibioprophylaxie individuelle adaptée à la flore du site opératoire et au risque du patient en cas de parcours de soins prolongé, colonisation cutanée à germes multi-résistants, ou immunodépression sous-jacente (Avis d'experts)."
         },
         {
-          "id": "brule-arthrodese-enfouissement-lambeau",
-          "nom": "Arthrodèse avec articulation fermée / Enfouissement de cartilage pour reconstruction auriculaire / Lambeau à distance à pédicule ou vascularisation transitoire",
+          "id": "brule-arthrodese-enfouissement-lambeau-part1",
+          "nom": "Arthrodèse avec articulation fermée",
+          "specialite": "Chirurgie du patient brûlé",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 63,
+          "source_tableau": "Tableau Chirurgie du patient brûlé",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Antibioprophylaxie adaptée à la flore du site opératoire et au risque du patient. Considérer une antibioprophylaxie individuelle adaptée à la flore du site opératoire et au risque du patient en cas de parcours de soins prolongé, colonisation cutanée à germes multi-résistants, ou immunodépression sous-jacente (Avis d'experts)."
+        },
+        {
+          "id": "brule-arthrodese-enfouissement-lambeau-part2",
+          "nom": "Enfouissement de cartilage pour reconstruction auriculaire",
+          "specialite": "Chirurgie du patient brûlé",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 63,
+          "source_tableau": "Tableau Chirurgie du patient brûlé",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Antibioprophylaxie adaptée à la flore du site opératoire et au risque du patient. Considérer une antibioprophylaxie individuelle adaptée à la flore du site opératoire et au risque du patient en cas de parcours de soins prolongé, colonisation cutanée à germes multi-résistants, ou immunodépression sous-jacente (Avis d'experts)."
+        },
+        {
+          "id": "brule-arthrodese-enfouissement-lambeau-part3",
+          "nom": "Lambeau à distance à pédicule ou vascularisation transitoire",
           "specialite": "Chirurgie du patient brûlé",
           "force_recommandation": "Avis d'experts",
           "source_page": 63,
@@ -3180,8 +4583,8 @@
       "nom": "Chirurgie gynécologique — Sein",
       "interventions": [
         {
-          "id": "gyno-sein-tumorectomie-sans-curage",
-          "nom": "Tumorectomie mammaire sans curage / Tumorectomie mammaire avec ganglion sentinelle",
+          "id": "gyno-sein-tumorectomie-sans-curage-part1",
+          "nom": "Tumorectomie mammaire sans curage",
           "specialite": "Chirurgie gynécologique — Sein",
           "force_recommandation": "Avis d'experts",
           "source_page": 64,
@@ -3191,8 +4594,19 @@
           "notes": null
         },
         {
-          "id": "gyno-sein-tumorectomie-curage-mastectomie",
-          "nom": "Tumorectomie mammaire avec curage axillaire / Mastectomie sans ou avec curage, sans ou avec reconstruction immédiate",
+          "id": "gyno-sein-tumorectomie-sans-curage-part2",
+          "nom": "Tumorectomie mammaire avec ganglion sentinelle",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 64,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique carcinologique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-sein-tumorectomie-curage-mastectomie-part1",
+          "nom": "Tumorectomie mammaire avec curage axillaire",
           "specialite": "Chirurgie gynécologique — Sein",
           "force_recommandation": "GRADE 2",
           "source_page": 64,
@@ -3213,8 +4627,30 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "gyno-sein-reduction-ablation-implant",
-          "nom": "Mastoplastie unilatérale ou bilatérale de réduction / Mastopexie pour ptose simple / Ablation uni- ou bilatérale d'implant prothétique mammaire sans ou avec capsulectomie",
+          "id": "gyno-sein-tumorectomie-curage-mastectomie-part2",
+          "nom": "Mastectomie sans ou avec curage, sans ou avec reconstruction immédiate",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "GRADE 2",
+          "source_page": 64,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique carcinologique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-sein-reduction-ablation-implant-part1",
+          "nom": "Mastoplastie unilatérale ou bilatérale de réduction",
           "specialite": "Chirurgie gynécologique — Sein",
           "force_recommandation": "Avis d'experts",
           "source_page": 65,
@@ -3224,8 +4660,30 @@
           "notes": null
         },
         {
-          "id": "gyno-sein-reconstruction-implant-lambeau",
-          "nom": "Mastoplastie ou reconstruction avec pose d'implant prothétique ou lambeau / Changement d'implant prothétique mammaire",
+          "id": "gyno-sein-reduction-ablation-implant-part2",
+          "nom": "Mastopexie pour ptose simple",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 65,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique esthétique/reconstruction",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-sein-reduction-ablation-implant-part3",
+          "nom": "Ablation uni- ou bilatérale d'implant prothétique mammaire sans ou avec capsulectomie",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 65,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique esthétique/reconstruction",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-sein-reconstruction-implant-lambeau-part1",
+          "nom": "Mastoplastie ou reconstruction avec pose d'implant prothétique ou lambeau",
           "specialite": "Chirurgie gynécologique — Sein",
           "force_recommandation": "Avis d'experts",
           "source_page": 65,
@@ -3246,8 +4704,41 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "gyno-sein-mamelon-lipofilling-petit",
-          "nom": "Chirurgie du mamelon ou de la plaque aréolo-mamelonnaire / Autogreffe de tissu adipeux < 200 cm³ au niveau du sein ET chirurgie < 2h",
+          "id": "gyno-sein-reconstruction-implant-lambeau-part2",
+          "nom": "Changement d'implant prothétique mammaire",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 65,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique esthétique/reconstruction",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-sein-mamelon-lipofilling-petit-part1",
+          "nom": "Chirurgie du mamelon ou de la plaque aréolo-mamelonnaire",
+          "specialite": "Chirurgie gynécologique — Sein",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 65,
+          "source_tableau": "Tableau Chirurgie gynécologique — Sein — Chirurgie sénologique esthétique/reconstruction",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-sein-mamelon-lipofilling-petit-part2",
+          "nom": "Autogreffe de tissu adipeux < 200 cm³ au niveau du sein ET chirurgie < 2h",
           "specialite": "Chirurgie gynécologique — Sein",
           "force_recommandation": "Avis d'experts",
           "source_page": 65,
@@ -3285,8 +4776,8 @@
       "nom": "Chirurgie gynécologique — Utérus, annexes et vulve",
       "interventions": [
         {
-          "id": "gyno-annexes-coelio-pas-abp",
-          "nom": "Coelioscopie diagnostique / Ligature ou déligature de trompe, détorsion d'annexe / Plastie tubaire, fimbrioplastie, salpingectomie / Drilling ovarien, kystectomie ovarienne, transposition ovarienne / Ponction de kyste / Ablation de dispositif intra-utérin (par coelioscopie)",
+          "id": "gyno-annexes-coelio-pas-abp-part1",
+          "nom": "Coelioscopie diagnostique",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 66,
@@ -3296,8 +4787,151 @@
           "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
         },
         {
-          "id": "gyno-annexes-coelio-avec-abp",
-          "nom": "Annexectomie / Ovariectomie / Débulking ovarien / Curage pelvien et/ou lombo-aortique / Omentectomie (par voie coelioscopique ou robotique)",
+          "id": "gyno-annexes-coelio-pas-abp-part2",
+          "nom": "Ligature ou déligature de trompe, détorsion d'annexe",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-annexes-coelio-pas-abp-part3",
+          "nom": "Plastie tubaire, fimbrioplastie, salpingectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-annexes-coelio-pas-abp-part4",
+          "nom": "Drilling ovarien, kystectomie ovarienne, transposition ovarienne",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-annexes-coelio-pas-abp-part5",
+          "nom": "Ponction de kyste",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-annexes-coelio-pas-abp-part6",
+          "nom": "Ablation de dispositif intra-utérin (par coelioscopie)",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Pour la cœlio-chirurgie des trompes, considérer une antibioprophylaxie par céfazoline limitée à la période opératoire en cas d'endométriose, d'antécédent de chirurgie pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-annexes-coelio-avec-abp-part1",
+          "nom": "Annexectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-coelio-avec-abp-part2",
+          "nom": "Ovariectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-coelio-avec-abp-part3",
+          "nom": "Débulking ovarien",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-coelio-avec-abp-part4",
+          "nom": "Curage pelvien et/ou lombo-aortique",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 66,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-coelio-avec-abp-part5",
+          "nom": "Omentectomie (par voie coelioscopique ou robotique)",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "GRADE 2",
           "source_page": 66,
@@ -3340,8 +4974,74 @@
           "notes": null
         },
         {
-          "id": "gyno-annexes-laparo",
-          "nom": "Chirurgie tubaire / Annexectomie, ovariectomie / Curage pelvien et/ou lombo-aortique / Omentectomie (par voie laparotomique)",
+          "id": "gyno-annexes-laparo-part1",
+          "nom": "Chirurgie tubaire",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie laparotomique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-laparo-part2",
+          "nom": "Annexectomie, ovariectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie laparotomique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-laparo-part3",
+          "nom": "Curage pelvien et/ou lombo-aortique",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie des annexes par voie laparotomique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-annexes-laparo-part4",
+          "nom": "Omentectomie (par voie laparotomique)",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "GRADE 2",
           "source_page": 67,
@@ -3384,8 +5084,8 @@
           "notes": null
         },
         {
-          "id": "gyno-uterus-hysterectomie-totale",
-          "nom": "Hystérectomie totale sans ou avec annexectomie / Colpo-hystérectomie élargie / Colpo-trachélectomie élargie (par voie laparotomique, coelioscopique ou robotique)",
+          "id": "gyno-uterus-hysterectomie-totale-part1",
+          "nom": "Hystérectomie totale sans ou avec annexectomie",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 67,
@@ -3406,8 +5106,52 @@
           "notes": null
         },
         {
-          "id": "gyno-uterus-hysterectomie-subtotale",
-          "nom": "Hystérectomie subtotale sans ou avec annexectomie (sans temps vaginal) / Myomectomie / Cerclage de l'isthme utérin en dehors de la grossesse / Hystérorraphie, hystéroplastie",
+          "id": "gyno-uterus-hysterectomie-totale-part2",
+          "nom": "Colpo-hystérectomie élargie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie laparotomique, coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-totale-part3",
+          "nom": "Colpo-trachélectomie élargie (par voie laparotomique, coelioscopique ou robotique)",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie laparotomique, coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-subtotale-part1",
+          "nom": "Hystérectomie subtotale sans ou avec annexectomie (sans temps vaginal)",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "GRADE 2",
           "source_page": 67,
@@ -3428,8 +5172,74 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "gyno-uterus-voie-vaginale-pas-abp",
-          "nom": "Conisation, curetage du corps de l'utérus, destruction de la muqueuse utérine par thermocontact / Cerclage de l'isthme utérin par abord vaginal / Destruction de lésions du col / Élargissement de l'orifice externe du col / Section de cloisons ou synéchies utérines / Résection de myome / Hystéroscopie diagnostique / Pose de dispositif intra-utérin",
+          "id": "gyno-uterus-hysterectomie-subtotale-part2",
+          "nom": "Myomectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie laparotomique, coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-subtotale-part3",
+          "nom": "Cerclage de l'isthme utérin en dehors de la grossesse",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie laparotomique, coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-subtotale-part4",
+          "nom": "Hystérorraphie, hystéroplastie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie laparotomique, coelioscopique ou robotique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part1",
+          "nom": "Conisation, curetage du corps de l'utérus, destruction de la muqueuse utérine par thermocontact",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 67,
@@ -3439,8 +5249,107 @@
           "notes": null
         },
         {
-          "id": "gyno-uterus-hysterectomie-vaginale",
-          "nom": "Hystérectomie avec et sans annexectomie / Colpectomie subtotale ou totale (par voie vaginale)",
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part2",
+          "nom": "Cerclage de l'isthme utérin par abord vaginal",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part3",
+          "nom": "Destruction de lésions du col",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part4",
+          "nom": "Élargissement de l'orifice externe du col",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part5",
+          "nom": "Section de cloisons ou synéchies utérines",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part6",
+          "nom": "Résection de myome",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part7",
+          "nom": "Hystéroscopie diagnostique",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-voie-vaginale-pas-abp-part8",
+          "nom": "Pose de dispositif intra-utérin",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 67,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-vaginale-part1",
+          "nom": "Hystérectomie avec et sans annexectomie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 68,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie de l'utérus par voie vaginale",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine + Gentamicine",
+              "dose_initiale": "900 mg IVL + 6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "gyno-uterus-hysterectomie-vaginale-part2",
+          "nom": "Colpectomie subtotale ou totale (par voie vaginale)",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 68,
@@ -3505,8 +5414,8 @@
           "notes": null
         },
         {
-          "id": "gyno-vulvaire-profonde-carcino",
-          "nom": "Vulvectomie partielle avec curage lymphonodal inguinal unilatéral / Vulvectomie totale sans ou avec curage inguinal et/ou iliaque, uni- ou bilatéral / Périnéotomie médiane avec lambeau cutané périnéal",
+          "id": "gyno-vulvaire-profonde-carcino-part1",
+          "nom": "Vulvectomie partielle avec curage lymphonodal inguinal unilatéral",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 69,
@@ -3527,8 +5436,52 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "gyno-vaginale-pas-abp",
-          "nom": "Chirurgie de l'hymen / Résection de cloison du vagin / Destruction de lésions vaginales avec ou sans laser",
+          "id": "gyno-vulvaire-profonde-carcino-part2",
+          "nom": "Vulvectomie totale sans ou avec curage inguinal et/ou iliaque, uni- ou bilatéral",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie vulvaire profonde et/ou carcinologique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-vulvaire-profonde-carcino-part3",
+          "nom": "Périnéotomie médiane avec lambeau cutané périnéal",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie vulvaire profonde et/ou carcinologique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "gyno-vaginale-pas-abp-part1",
+          "nom": "Chirurgie de l'hymen",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 69,
@@ -3538,8 +5491,30 @@
           "notes": null
         },
         {
-          "id": "gyno-avortement",
-          "nom": "Révision de la cavité de l'utérus après avortement / Évacuation d'un utérus gravide par aspiration et/ou curetage au 1er trimestre / Évacuation d'un utérus gravide au 2e trimestre avant la 22e SA",
+          "id": "gyno-vaginale-pas-abp-part2",
+          "nom": "Résection de cloison du vagin",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-vaginale-pas-abp-part3",
+          "nom": "Destruction de lésions vaginales avec ou sans laser",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Chirurgie vaginale",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-avortement-part1",
+          "nom": "Révision de la cavité de l'utérus après avortement",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "GRADE 2",
           "source_page": 69,
@@ -3549,8 +5524,30 @@
           "notes": null
         },
         {
-          "id": "gyno-pma",
-          "nom": "Prélèvement d'ovocytes par voie transvaginale avec échoguidage / Prélèvement d'ovocytes par cœlioscopie / Transfert intra-utérin d'embryon par voie vaginale",
+          "id": "gyno-avortement-part2",
+          "nom": "Évacuation d'un utérus gravide par aspiration et/ou curetage au 1er trimestre",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Avortement, grossesse arrêtée",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-avortement-part3",
+          "nom": "Évacuation d'un utérus gravide au 2e trimestre avant la 22e SA",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 2",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Avortement, grossesse arrêtée",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-pma-part1",
+          "nom": "Prélèvement d'ovocytes par voie transvaginale avec échoguidage",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "GRADE 1",
           "source_page": 69,
@@ -3560,8 +5557,41 @@
           "notes": "Considérer une antibioprophylaxie par céfazoline limitée à la période opératoire pour la ponction ovocytaire et le transfert embryonnaire en cas d'endométriose, d'antécédent de chirurgies pelviennes ou d'infection génitale haute (Avis d'experts)."
         },
         {
-          "id": "gyno-embolisation",
-          "nom": "Embolisation de fibromes utérins / Embolisation de varices pelviennes sans abord chirurgical du scarpa",
+          "id": "gyno-pma-part2",
+          "nom": "Prélèvement d'ovocytes par cœlioscopie",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 1",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Procréation médicalement assistée",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Considérer une antibioprophylaxie par céfazoline limitée à la période opératoire pour la ponction ovocytaire et le transfert embryonnaire en cas d'endométriose, d'antécédent de chirurgies pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-pma-part3",
+          "nom": "Transfert intra-utérin d'embryon par voie vaginale",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "GRADE 1",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Procréation médicalement assistée",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": "Considérer une antibioprophylaxie par céfazoline limitée à la période opératoire pour la ponction ovocytaire et le transfert embryonnaire en cas d'endométriose, d'antécédent de chirurgies pelviennes ou d'infection génitale haute (Avis d'experts)."
+        },
+        {
+          "id": "gyno-embolisation-part1",
+          "nom": "Embolisation de fibromes utérins",
+          "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 69,
+          "source_tableau": "Tableau Chirurgie gynécologique — Utérus, annexes et vulve — Embolisation",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "gyno-embolisation-part2",
+          "nom": "Embolisation de varices pelviennes sans abord chirurgical du scarpa",
           "specialite": "Chirurgie gynécologique — Utérus, annexes et vulve",
           "force_recommandation": "Avis d'experts",
           "source_page": 69,
@@ -3577,8 +5607,8 @@
       "nom": "Chirurgie obstétricale",
       "interventions": [
         {
-          "id": "obs-cesarienne",
-          "nom": "Accouchement par césarienne programmée ou en urgence, en dehors ou en cours de travail / Suture du corps de l'utérus pour rupture obstétricale",
+          "id": "obs-cesarienne-part1",
+          "nom": "Accouchement par césarienne programmée ou en urgence, en dehors ou en cours de travail",
           "specialite": "Chirurgie obstétricale",
           "force_recommandation": "GRADE 2",
           "source_page": 70,
@@ -3592,8 +5622,34 @@
           "notes": "Injection de l'antibioprophylaxie autant que possible avant l'incision (GRADE 2). Pas d'alternative proposée à la céfazoline du fait de données rapportées quasi-exclusivement pour cette molécule."
         },
         {
-          "id": "obs-cerclage",
-          "nom": "Cerclage du col de l'utérus au cours de la grossesse, par voie transvaginale / Ablation de cerclage du col de l'utérus",
+          "id": "obs-cesarienne-part2",
+          "nom": "Suture du corps de l'utérus pour rupture obstétricale",
+          "specialite": "Chirurgie obstétricale",
+          "force_recommandation": "GRADE 2",
+          "source_page": 70,
+          "source_tableau": "Tableau Chirurgie obstétricale — Césarienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": null,
+          "notes": "Injection de l'antibioprophylaxie autant que possible avant l'incision (GRADE 2). Pas d'alternative proposée à la céfazoline du fait de données rapportées quasi-exclusivement pour cette molécule."
+        },
+        {
+          "id": "obs-cerclage-part1",
+          "nom": "Cerclage du col de l'utérus au cours de la grossesse, par voie transvaginale",
+          "specialite": "Chirurgie obstétricale",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 70,
+          "source_tableau": "Tableau Chirurgie obstétricale — Cerclage du col utérin",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "obs-cerclage-part2",
+          "nom": "Ablation de cerclage du col de l'utérus",
           "specialite": "Chirurgie obstétricale",
           "force_recommandation": "Avis d'experts",
           "source_page": 70,
@@ -3636,8 +5692,30 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL."
         },
         {
-          "id": "obs-delivrance-revision-uterine",
-          "nom": "Révision de la cavité de l'utérus après délivrance naturelle / Extraction manuelle du placenta complet",
+          "id": "obs-delivrance-revision-uterine-part1",
+          "nom": "Révision de la cavité de l'utérus après délivrance naturelle",
+          "specialite": "Chirurgie obstétricale",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 70,
+          "source_tableau": "Tableau Chirurgie obstétricale — Délivrance artificielle / révision utérine",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique lors de la révision ou de la délivrance manuelle"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL."
+        },
+        {
+          "id": "obs-delivrance-revision-uterine-part2",
+          "nom": "Extraction manuelle du placenta complet",
           "specialite": "Chirurgie obstétricale",
           "force_recommandation": "Avis d'experts",
           "source_page": 70,
@@ -3691,8 +5769,30 @@
           "notes": null
         },
         {
-          "id": "obs-ligatures-vasculaires",
-          "nom": "Ligature des artères iliaques internes pour hémorragie du post-partum / Ligature des pédicules vasculaires de l'utérus pour hémorragie du post-partum (par laparotomie)",
+          "id": "obs-ligatures-vasculaires-part1",
+          "nom": "Ligature des artères iliaques internes pour hémorragie du post-partum",
+          "specialite": "Chirurgie obstétricale",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 71,
+          "source_tableau": "Tableau Chirurgie obstétricale — Ligatures vasculaires",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "obs-ligatures-vasculaires-part2",
+          "nom": "Ligature des pédicules vasculaires de l'utérus pour hémorragie du post-partum (par laparotomie)",
           "specialite": "Chirurgie obstétricale",
           "force_recommandation": "Avis d'experts",
           "source_page": 71,
@@ -3719,8 +5819,8 @@
       "nom": "Chirurgie digestive",
       "interventions": [
         {
-          "id": "digest-oesophagectomie",
-          "nom": "Œsophagectomie / Excision de tumeur de l'œsophage / Traitement d'un diverticule de l'œsophage",
+          "id": "digest-oesophagectomie-part1",
+          "nom": "Œsophagectomie",
           "specialite": "Chirurgie digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 79,
@@ -3747,8 +5847,92 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "digest-gastrectomie",
-          "nom": "Gastrectomie totale, totalisation de gastrectomie / Gastrectomie partielle",
+          "id": "digest-oesophagectomie-part2",
+          "nom": "Excision de tumeur de l'œsophage",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 79,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie œsophagienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "digest-oesophagectomie-part3",
+          "nom": "Traitement d'un diverticule de l'œsophage",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 79,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie œsophagienne",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "digest-gastrectomie-part1",
+          "nom": "Gastrectomie totale, totalisation de gastrectomie",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 79,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie gastrique non bariatrique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "digest-gastrectomie-part2",
+          "nom": "Gastrectomie partielle",
           "specialite": "Chirurgie digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 79,
@@ -3825,8 +6009,8 @@
           "notes": null
         },
         {
-          "id": "digest-intestin-grele",
-          "nom": "Résection de l'intestin grêle / Entérostomie cutanée, par laparotomie",
+          "id": "digest-intestin-grele-part1",
+          "nom": "Résection de l'intestin grêle",
           "specialite": "Chirurgie digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 79,
@@ -3847,8 +6031,96 @@
           "notes": null
         },
         {
-          "id": "digest-colorectal",
-          "nom": "Colectomie / Amputation abdomino-périnéale / Proctectomie / Rétablissement de continuité",
+          "id": "digest-intestin-grele-part2",
+          "nom": "Entérostomie cutanée, par laparotomie",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 79,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie de l'intestin grêle",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "digest-colorectal-part1",
+          "nom": "Colectomie",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "GRADE 1",
+          "source_page": 80,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie colorectale et appendiculaire",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "La veille soir : Tobramycine 200mg per os (dose unique, GRADE 1) + Métronidazole 1g per os (dose unique, Avis d'experts). Lors de la chirurgie : Céfoxitine 2g IVL (GRADE 1)."
+        },
+        {
+          "id": "digest-colorectal-part2",
+          "nom": "Amputation abdomino-périnéale",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "GRADE 1",
+          "source_page": 80,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie colorectale et appendiculaire",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "La veille soir : Tobramycine 200mg per os (dose unique, GRADE 1) + Métronidazole 1g per os (dose unique, Avis d'experts). Lors de la chirurgie : Céfoxitine 2g IVL (GRADE 1)."
+        },
+        {
+          "id": "digest-colorectal-part3",
+          "nom": "Proctectomie",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "GRADE 1",
+          "source_page": 80,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie colorectale et appendiculaire",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "La veille soir : Tobramycine 200mg per os (dose unique, GRADE 1) + Métronidazole 1g per os (dose unique, Avis d'experts). Lors de la chirurgie : Céfoxitine 2g IVL (GRADE 1)."
+        },
+        {
+          "id": "digest-colorectal-part4",
+          "nom": "Rétablissement de continuité",
           "specialite": "Chirurgie digestive",
           "force_recommandation": "GRADE 1",
           "source_page": 80,
@@ -3891,8 +6163,38 @@
           "notes": null
         },
         {
-          "id": "digest-proctologique",
-          "nom": "Hémorroïdes / Kyste pilonidal / Fistule anale",
+          "id": "digest-proctologique-part1",
+          "nom": "Hémorroïdes",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 80,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie proctologique",
+          "protocole": {
+            "molecule": "Métronidazole",
+            "dose_initiale": "1g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "digest-proctologique-part2",
+          "nom": "Kyste pilonidal",
+          "specialite": "Chirurgie digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 80,
+          "source_tableau": "Tableau Chirurgie digestive — Chirurgie proctologique",
+          "protocole": {
+            "molecule": "Métronidazole",
+            "dose_initiale": "1g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "digest-proctologique-part3",
+          "nom": "Fistule anale",
           "specialite": "Chirurgie digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 80,
@@ -3951,8 +6253,8 @@
           "notes": null
         },
         {
-          "id": "hbs-cholecystectomie-laparo-avec-calcul",
-          "nom": "Cholécystectomie par laparotomie / Cholécystectomie avec ablation transcystique ou choledocotomie de calcul de la VBP / Ablation de calcul de la voie biliaire principale, par laparoscopie ou laparotomie",
+          "id": "hbs-cholecystectomie-laparo-avec-calcul-part1",
+          "nom": "Cholécystectomie par laparotomie",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "Avis d'experts",
           "source_page": 81,
@@ -3979,8 +6281,64 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "hbs-anastomose-bilio-digestive",
-          "nom": "Cholécystectomie avec choledoco-jéjunostomie / Résection de la voie biliaire principale pédiculaire avec anastomose bilio-digestive, par laparotomie",
+          "id": "hbs-cholecystectomie-laparo-avec-calcul-part2",
+          "nom": "Cholécystectomie avec ablation transcystique ou choledocotomie de calcul de la VBP",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 81,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie de la vésicule biliaire et des voies biliaires",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-cholecystectomie-laparo-avec-calcul-part3",
+          "nom": "Ablation de calcul de la voie biliaire principale, par laparoscopie ou laparotomie",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 81,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie de la vésicule biliaire et des voies biliaires",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-anastomose-bilio-digestive-part1",
+          "nom": "Cholécystectomie avec choledoco-jéjunostomie",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "Avis d'experts",
           "source_page": 82,
@@ -4001,8 +6359,30 @@
           "notes": null
         },
         {
-          "id": "hbs-hepatectomie",
-          "nom": "Résection atypique du foie / Uni-, bi-, ou tri-segmentectomie du foie / Lobectomie hépatique gauche ou droite (laparo ou coelioscopique)",
+          "id": "hbs-anastomose-bilio-digestive-part2",
+          "nom": "Résection de la voie biliaire principale pédiculaire avec anastomose bilio-digestive, par laparotomie",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Anastomose bilio-digestive",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "hbs-hepatectomie-part1",
+          "nom": "Résection atypique du foie",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "Avis d'experts",
           "source_page": 82,
@@ -4029,8 +6409,86 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "hbs-kystes-hepatiques",
-          "nom": "Résection du dôme saillant / Péri-kystectomie / Chirurgie de kystes hydatiques",
+          "id": "hbs-hepatectomie-part2",
+          "nom": "Uni-, bi-, ou tri-segmentectomie du foie",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Hépatectomie sans chirurgie des voies biliaires",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-hepatectomie-part3",
+          "nom": "Lobectomie hépatique gauche ou droite (laparo ou coelioscopique)",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Hépatectomie sans chirurgie des voies biliaires",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-kystes-hepatiques-part1",
+          "nom": "Résection du dôme saillant",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie des kystes hépatiques simples",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "hbs-kystes-hepatiques-part2",
+          "nom": "Péri-kystectomie",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie des kystes hépatiques simples",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "hbs-kystes-hepatiques-part3",
+          "nom": "Chirurgie de kystes hydatiques",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "Avis d'experts",
           "source_page": 82,
@@ -4068,8 +6526,8 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "hbs-pancreatectomie",
-          "nom": "Pancréatectomie gauche avec ou sans conservation de la rate / Pancréatectomie totale ou subtotale avec conservation du duodénum / Gestes d'épargne pancréatique (isthmectomie, exérèse de tumeur)",
+          "id": "hbs-pancreatectomie-part1",
+          "nom": "Pancréatectomie gauche avec ou sans conservation de la rate",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "GRADE 2",
           "source_page": 82,
@@ -4096,8 +6554,86 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "hbs-dpc-sans-drainage-preop",
-          "nom": "Duodéno-pancréatectomie céphalique (DPC) sans geste de drainage biliaire préopératoire / Duodéno-pancréatectomie totale (DPT) sans geste de drainage biliaire préopératoire",
+          "id": "hbs-pancreatectomie-part2",
+          "nom": "Pancréatectomie totale ou subtotale avec conservation du duodénum",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "GRADE 2",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie pancréatique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-pancreatectomie-part3",
+          "nom": "Gestes d'épargne pancréatique (isthmectomie, exérèse de tumeur)",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "GRADE 2",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie pancréatique",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Vancomycine",
+              "dose_initiale": "20 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Teicoplanine",
+              "dose_initiale": "12 mg/kg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "hbs-dpc-sans-drainage-preop-part1",
+          "nom": "Duodéno-pancréatectomie céphalique (DPC) sans geste de drainage biliaire préopératoire",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "GRADE 1",
+          "source_page": 82,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Chirurgie pancréatique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "hbs-dpc-sans-drainage-preop-part2",
+          "nom": "Duodéno-pancréatectomie totale (DPT) sans geste de drainage biliaire préopératoire",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "GRADE 1",
           "source_page": 82,
@@ -4133,8 +6669,74 @@
           "notes": null
         },
         {
-          "id": "hbs-transplantation-foie-pancreas",
-          "nom": "Transplantation de foie total / Transplantation de foie réduit / Transplantation du pancréas / Transplantation du pancréas et du rein",
+          "id": "hbs-transplantation-foie-pancreas-part1",
+          "nom": "Transplantation de foie total",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 83,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Transplantation hépatique et pancréatique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Spectre à élargir et/ou à adapter à l'écologie locale si facteurs de risque de BMR et/ou antécédent d'infection fongique (Avis d'experts)."
+        },
+        {
+          "id": "hbs-transplantation-foie-pancreas-part2",
+          "nom": "Transplantation de foie réduit",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 83,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Transplantation hépatique et pancréatique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Spectre à élargir et/ou à adapter à l'écologie locale si facteurs de risque de BMR et/ou antécédent d'infection fongique (Avis d'experts)."
+        },
+        {
+          "id": "hbs-transplantation-foie-pancreas-part3",
+          "nom": "Transplantation du pancréas",
+          "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 83,
+          "source_tableau": "Tableau Chirurgie hépatobiliaire, splénique et pancréatique — Transplantation hépatique et pancréatique",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 2h, puis toutes les 2h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Spectre à élargir et/ou à adapter à l'écologie locale si facteurs de risque de BMR et/ou antécédent d'infection fongique (Avis d'experts)."
+        },
+        {
+          "id": "hbs-transplantation-foie-pancreas-part4",
+          "nom": "Transplantation du pancréas et du rein",
           "specialite": "Chirurgie hépatobiliaire, splénique et pancréatique",
           "force_recommandation": "Avis d'experts",
           "source_page": 83,
@@ -4211,8 +6813,52 @@
           "notes": null
         },
         {
-          "id": "endo-cpre-drainage-incomplet",
-          "nom": "Cholangioscopie ou pancréatoscopie avec ou sans lithotritie / Dilatation et pose de prothèses biliaires ou pancréatiques avec drainage biliaire incomplet / Extraction de calculs avec drainage biliaire incomplet",
+          "id": "endo-cpre-drainage-incomplet-part1",
+          "nom": "Cholangioscopie ou pancréatoscopie avec ou sans lithotritie",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Cholangio-pancréatographie rétrograde endoscopique (CPRE)",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-cpre-drainage-incomplet-part2",
+          "nom": "Dilatation et pose de prothèses biliaires ou pancréatiques avec drainage biliaire incomplet",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Cholangio-pancréatographie rétrograde endoscopique (CPRE)",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-cpre-drainage-incomplet-part3",
+          "nom": "Extraction de calculs avec drainage biliaire incomplet",
           "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 84,
@@ -4255,8 +6901,8 @@
           "notes": null
         },
         {
-          "id": "endo-echo-ponction-kystique-avec-risque",
-          "nom": "Ponction de lésion kystique pancréatique avec facteur(s) de risque d'infection / Kysto-gastrostomie / Ponction de liquide d'ascite / Ponction liquide pleural per endoscopique / Constitution d'une anastomose gastro-jéjunale sous écho-endoscopie",
+          "id": "endo-echo-ponction-kystique-avec-risque-part1",
+          "nom": "Ponction de lésion kystique pancréatique avec facteur(s) de risque d'infection",
           "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 84,
@@ -4277,8 +6923,107 @@
           "notes": null
         },
         {
-          "id": "endo-fibroscopie-haute",
-          "nom": "Fibroscopie œso-gastro-duodénale diagnostique avec ou sans biopsie / Fibroscopie thérapeutique avec dilatation, ou pose de prothèse, ou mucosectomie ou dissection sous-muqueuse",
+          "id": "endo-echo-ponction-kystique-avec-risque-part2",
+          "nom": "Kysto-gastrostomie",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Ponction sous écho-endoscopie",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-echo-ponction-kystique-avec-risque-part3",
+          "nom": "Ponction de liquide d'ascite",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Ponction sous écho-endoscopie",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-echo-ponction-kystique-avec-risque-part4",
+          "nom": "Ponction liquide pleural per endoscopique",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Ponction sous écho-endoscopie",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-echo-ponction-kystique-avec-risque-part5",
+          "nom": "Constitution d'une anastomose gastro-jéjunale sous écho-endoscopie",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 84,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Ponction sous écho-endoscopie",
+          "protocole": {
+            "molecule": "Céfoxitine",
+            "dose_initiale": "2g IVL",
+            "reinjection": "Dose unique"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine + Métronidazole",
+              "dose_initiale": "6-7 mg/kg IVL + 1g IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": null
+        },
+        {
+          "id": "endo-fibroscopie-haute-part1",
+          "nom": "Fibroscopie œso-gastro-duodénale diagnostique avec ou sans biopsie",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 85,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Endoscopie digestive haute",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "endo-fibroscopie-haute-part2",
+          "nom": "Fibroscopie thérapeutique avec dilatation, ou pose de prothèse, ou mucosectomie ou dissection sous-muqueuse",
           "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 85,
@@ -4342,8 +7087,8 @@
           "notes": null
         },
         {
-          "id": "endo-coloscopie",
-          "nom": "Coloscopie diagnostique avec ou sans biopsie / Coloscopie thérapeutique avec dilatation, pose de prothèse, mucosectomie ou dissection sous-muqueuse",
+          "id": "endo-coloscopie-part1",
+          "nom": "Coloscopie diagnostique avec ou sans biopsie",
           "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 85,
@@ -4353,8 +7098,41 @@
           "notes": null
         },
         {
-          "id": "endo-radio-embolisation-hepatique",
-          "nom": "Chimio-embolisation / Embolisation hépatique / Shunt porto-systémique intra-hépatique transjugulaire",
+          "id": "endo-coloscopie-part2",
+          "nom": "Coloscopie thérapeutique avec dilatation, pose de prothèse, mucosectomie ou dissection sous-muqueuse",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 85,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Endoscopie digestive basse",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "endo-radio-embolisation-hepatique-part1",
+          "nom": "Chimio-embolisation",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 86,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Radiologie interventionnelle digestive — Embolisation hépatique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "endo-radio-embolisation-hepatique-part2",
+          "nom": "Embolisation hépatique",
+          "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 86,
+          "source_tableau": "Tableau Endoscopie digestive et radiologie interventionnelle digestive — Radiologie interventionnelle digestive — Embolisation hépatique",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "endo-radio-embolisation-hepatique-part3",
+          "nom": "Shunt porto-systémique intra-hépatique transjugulaire",
           "specialite": "Endoscopie digestive et radiologie interventionnelle digestive",
           "force_recommandation": "Avis d'experts",
           "source_page": 86,
@@ -4403,8 +7181,30 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "uro-adenomectomie-holep",
-          "nom": "Adénomectomie chirurgicale / Traitement de l'HBP par d'autres techniques (HoLEP, ThuLEP, GreenLEP, BIPOLEP, UROLIFT, REZUM)",
+          "id": "uro-adenomectomie-holep-part1",
+          "nom": "Adénomectomie chirurgicale",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 88,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie de la prostate",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "uro-adenomectomie-holep-part2",
+          "nom": "Traitement de l'HBP par d'autres techniques (HoLEP, ThuLEP, GreenLEP, BIPOLEP, UROLIFT, REZUM)",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 88,
@@ -4447,8 +7247,19 @@
           "notes": null
         },
         {
-          "id": "uro-curietherapie-biopsies-trans-perineale",
-          "nom": "Curiethérapie / Biopsies de prostate par voie trans-périnéale",
+          "id": "uro-curietherapie-biopsies-trans-perineale-part1",
+          "nom": "Curiethérapie",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 88,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie de la prostate",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "uro-curietherapie-biopsies-trans-perineale-part2",
+          "nom": "Biopsies de prostate par voie trans-périnéale",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 88,
@@ -4480,8 +7291,19 @@
           "notes": null
         },
         {
-          "id": "uro-cystoscopie-rtuv",
-          "nom": "Cystoscopie diagnostique / Résection trans-urétrale de vessie (RTUV)",
+          "id": "uro-cystoscopie-rtuv-part1",
+          "nom": "Cystoscopie diagnostique",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "GRADE 1",
+          "source_page": 88,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie de la vessie",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "uro-cystoscopie-rtuv-part2",
+          "nom": "Résection trans-urétrale de vessie (RTUV)",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "GRADE 1",
           "source_page": 88,
@@ -4513,8 +7335,30 @@
           "notes": null
         },
         {
-          "id": "uro-prolapsus-macroplastique",
-          "nom": "Cure de prolapsus quelle que soit la voie d'abord avec ou sans matériel / Injection de macroplastique",
+          "id": "uro-prolapsus-macroplastique-part1",
+          "nom": "Cure de prolapsus quelle que soit la voie d'abord avec ou sans matériel",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 88,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie de la vessie",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "uro-prolapsus-macroplastique-part2",
+          "nom": "Injection de macroplastique",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 88,
@@ -4557,8 +7401,36 @@
           "notes": null
         },
         {
-          "id": "uro-prothese-penienne-testiculaire",
-          "nom": "Pose de prothèse pénienne / Pose de prothèse testiculaire",
+          "id": "uro-prothese-penienne-testiculaire-part1",
+          "nom": "Pose de prothèse pénienne",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 89,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie des organes génitaux de l'homme",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            },
+            {
+              "molecule": "Clindamycine",
+              "dose_initiale": "900 mg IVL",
+              "intention": 2,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h). En cas d'allergie aux bêtalactamines pour chirurgie prothétique : ajouter Clindamycine 900mg IVL à la Gentamicine."
+        },
+        {
+          "id": "uro-prothese-penienne-testiculaire-part2",
+          "nom": "Pose de prothèse testiculaire",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 89,
@@ -4618,8 +7490,74 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "uro-uretrotomie-nephrostomie-nlpc",
-          "nom": "Urétrotomie, urétroplastie / Montée de sonde JJ / Pose de sonde de néphrostomie / Néphrolithotomie percutanée",
+          "id": "uro-uretrotomie-nephrostomie-nlpc-part1",
+          "nom": "Urétrotomie, urétroplastie",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 89,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie des voies excrétrices",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "uro-uretrotomie-nephrostomie-nlpc-part2",
+          "nom": "Montée de sonde JJ",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 89,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie des voies excrétrices",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "uro-uretrotomie-nephrostomie-nlpc-part3",
+          "nom": "Pose de sonde de néphrostomie",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 89,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgie des voies excrétrices",
+          "protocole": {
+            "molecule": "Céfazoline",
+            "dose_initiale": "2g IVL",
+            "reinjection": "1g si durée > 4h, puis toutes les 4h jusqu'à fin de chirurgie"
+          },
+          "alternative_allergie": [
+            {
+              "molecule": "Gentamicine",
+              "dose_initiale": "6-7 mg/kg IVL",
+              "intention": 1,
+              "reinjection": null
+            }
+          ],
+          "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
+        },
+        {
+          "id": "uro-uretrotomie-nephrostomie-nlpc-part4",
+          "nom": "Néphrolithotomie percutanée",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 89,
@@ -4673,8 +7611,41 @@
           "notes": "Alternative pharmacologique : Céfuroxime 1,5g IVL (0,75g si durée > 2h, puis toutes les 2h)."
         },
         {
-          "id": "uro-nephrectomie-surrenalectomie-ablation",
-          "nom": "Néphrectomie totale ou partielle / Surrénalectomie / Embolisation des artères rénales / Thermoablation de tumeur rénale",
+          "id": "uro-nephrectomie-surrenalectomie-ablation-part1",
+          "nom": "Néphrectomie totale ou partielle",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 90,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgies du rein",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "uro-nephrectomie-surrenalectomie-ablation-part2",
+          "nom": "Surrénalectomie",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 90,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgies du rein",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "uro-nephrectomie-surrenalectomie-ablation-part3",
+          "nom": "Embolisation des artères rénales",
+          "specialite": "Chirurgie urologique",
+          "force_recommandation": "Avis d'experts",
+          "source_page": 90,
+          "source_tableau": "Tableau Chirurgie urologique — Chirurgies du rein",
+          "protocole": null,
+          "alternative_allergie": null,
+          "notes": null
+        },
+        {
+          "id": "uro-nephrectomie-surrenalectomie-ablation-part4",
+          "nom": "Thermoablation de tumeur rénale",
           "specialite": "Chirurgie urologique",
           "force_recommandation": "Avis d'experts",
           "source_page": 90,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ branch = "main"
 changelog_file = "CHANGELOG.md"
 build_command = ""
 upload_to_pypi = false
-upload_to_release = true
+upload_to_vcs_release = true
 commit_message = "chore(release): v{version} [skip ci]"
 tag_format = "v{version}"
 


### PR DESCRIPTION
This pull request updates documentation to reflect a significant increase in the number of interventions and specialties loaded at server startup, and simplifies the release workflow to create GitHub releases automatically during versioning.

Documentation updates:

* Updated `README.md` to indicate that `data/rfe.json` now contains 406 interventions and 21 specialties, instead of the previous 47 interventions and 2 specialties.
* Updated the example API health check response in `README.md` to match the new counts for `specialites` (21) and `interventions` (406).

Release workflow improvements:

* Modified `.github/workflows/release.yml` so that the `semantic-release version` step now also creates a GitHub release, eliminating the need for a separate publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Documentation**
  * Mise à jour des statistiques de données : le produit contient maintenant 406 interventions et 21 spécialités; exemple d'endpoint mis à jour.

* **Chores**
  * Simplification du processus de publication : consolidation des étapes de versionnage et de création de release en une seule commande automatisée.
  * Ajustement de la configuration du mécanisme de publication pour refléter ce flux unifié.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->